### PR TITLE
Change Cron to Run Daily

### DIFF
--- a/.github/workflows/run-project-status-checker.yml
+++ b/.github/workflows/run-project-status-checker.yml
@@ -2,7 +2,7 @@ name: "Run Project Status Checker"
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
   push:
     branches: "main"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/workflows/run-project-status-checker.yml` file. The change modifies the schedule for the "Run Project Status Checker" workflow to run once daily at midnight instead of hourly.

* [`.github/workflows/run-project-status-checker.yml`](diffhunk://#diff-acd8df7c3dec8258b0608875cd6decf061ccb01c964b4da34cc29df6257bda67L5-R5): Updated the cron schedule from "0 * * * *" to "0 0 * * *" to run the workflow once daily at midnight.