### PR TITLE
Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: read
   packages: read
-  statuses: write
-  security-events: write
 
 jobs:
   check-code-quality:
     name: Check Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -23,10 +23,35 @@ jobs:
           fetch-depth: 0
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.2.0
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   labeller:
     name: Label Pull Request
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Label Pull Request

--- a/.github/workflows/run-project-status-checker.yml
+++ b/.github/workflows/run-project-status-checker.yml
@@ -7,13 +7,14 @@ on:
   push:
     branches: "main"
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   run-project-status-checker:
     name: Run Project Status Checker
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -7,13 +7,14 @@ on:
     paths:
       - .github/other-configurations/labels.yml
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   configure-labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     name: Configure Labels
     steps:
       - name: Checkout


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes several updates to the GitHub Actions workflows to improve permissions management and add a new job for checking GitHub Actions with zizmor. The most important changes are the addition of the `run-zizmor` job and the restructuring of permissions across multiple workflow files.

New job addition:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L12-R57): Added a new job `run-zizmor` to check GitHub Actions with zizmor, including steps for installing `uv`, running `zizmor`, and uploading SARIF files.

Permissions restructuring:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L12-R57): Updated permissions for the `check-code-quality` job and removed unnecessary permissions at the workflow level.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL7-R13): Removed workflow-level permissions and added specific permissions for the `labeller` job.
* [`.github/workflows/run-project-status-checker.yml`](diffhunk://#diff-acd8df7c3dec8258b0608875cd6decf061ccb01c964b4da34cc29df6257bda67L10-R17): Removed workflow-level permissions and added specific permissions for the `run-project-status-checker` job.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L10-R17): Removed workflow-level permissions and added specific permissions for the `configure-labels` job.