### PR TITLE
GitHub detect yml files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yml linguist-detectable


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.gitattributes` file. The change makes `.yml` files detectable by the linguist tool.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1): Added `*.yml linguist-detectable` to ensure `.yml` files are detected by linguist.