### PR TITLE
Allow .github files to be counted in stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.yml linguist-detectable
+.github/* linguist-vendored=false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.gitattributes` file. The change ensures that files in the `.github` directory are not treated as vendored code by the linguist tool.

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR2): Added a rule to set `linguist-vendored=false` for files in the `.github` directory.