### PR TITLE
Fix Zizmor Warnings

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v7.2.1

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: micnncim/action-label-syncer@v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflows to enhance security by preventing the persistence of credentials.

Security improvements:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R26): Added `persist-credentials: false` to the `actions/checkout` step to prevent credentials from being persisted.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R24): Added `persist-credentials: false` to the `actions/checkout` step to prevent credentials from being persisted.