### PR TITLE
Add Markdown Link Checker

### DIFF
--- a/.github/other-configurations/.linkspector.yml
+++ b/.github/other-configurations/.linkspector.yml
@@ -1,0 +1,4 @@
+dirs:
+  - ./
+aliveStatusCodes:
+  - 200

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -34,6 +34,24 @@ jobs:
           LINTER_RULES_PATH: .github/super-linter-configurations
           YAML_ERROR_ON_WARNING: true
 
+  check-markdown-links:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check Markdown links
+        uses: UmbrellaDocs/action-linkspector@v1.2.5
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          config_file: .github/other-configurations/.linkspector.yml
+          reporter: github-pr-review
+          fail_on_error: true
+          filter_mode: nofilter
+
   check-justfile-format:
     name: Check Justfile Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new workflow to check markdown links and adds a configuration file for the Linkspector tool. The most important changes include the addition of a new job in the GitHub Actions workflow and the creation of a configuration file for the link checker.

### New GitHub Actions Workflow:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R37-R54): Added a new job named `check-markdown-links` to check the validity of markdown links using the Linkspector tool. This job includes steps to checkout the repository and run the link checker with specified configurations.

### Configuration for Linkspector:

* [`.github/other-configurations/.linkspector.yml`](diffhunk://#diff-f9691f23ea6c4c34ecbaa23a98721e0aa3c7a94f2fcdd38f7b99fe863c5f6305R1-R4): Created a new configuration file for the Linkspector tool, specifying the directories to check and the status codes considered as alive.