### PR TITLE
Remove Git Attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.yml linguist-detectable
-.github/* linguist-vendored=false


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.gitattributes` file. The change removes the `linguist-detectable` attribute for `.yml` files and the `linguist-vendored=false` attribute for files in the `.github` directory.

Changes in file `.gitattributes`:

* Removed the `linguist-detectable` attribute for `.yml` files.
* Removed the `linguist-vendored=false` attribute for files in the `.github` directory.