### PR TITLE
Update Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/"
-    commit-message:
-      prefix: "deps(github-actions)"
     schedule:
       interval: "daily"
       time: "01:00"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change removes the `commit-message` prefix configuration for GitHub Actions dependencies. 

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-L8): Removed the `commit-message` prefix configuration for GitHub Actions dependencies.
