### PR TITLE
Add Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -112,3 +112,19 @@ jobs:
           config-file: .github/other-configurations/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.13
+
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new GitHub Actions job to validate Lefthook configurations in the `.github/workflows/code-checks.yml` file. The addition enhances the CI/CD pipeline by ensuring that Lefthook hooks are properly validated.

### New GitHub Actions Job:

* Added a `lefthook-validate` job to the workflow:
  - Configured to run on `ubuntu-latest`.
  - Includes steps to check out the repository, install the latest version of `uv`, and run the `lefthook validate` command.