### PR TITLE
Pin GitHub Actions

### DIFF
--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+# pinact - https://github.com/suzuki-shunsuke/pinact
+version: 3
+
+ignore_actions:
+  - name: actions/.*
+    ref: .*
+  - name: github/codeql-action/.*
+    ref: .*

--- a/.github/other-configurations/pinact.yml
+++ b/.github/other-configurations/pinact.yml
@@ -7,3 +7,5 @@ ignore_actions:
     ref: .*
   - name: github/codeql-action/.*
     ref: .*
+  - name: actions-js/push
+    ref: .*

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Check Markdown links
-        uses: UmbrellaDocs/action-linkspector@v1.3.4
+        uses: UmbrellaDocs/action-linkspector@a0567ce1c7c13de4a2358587492ed43cab5d0102 # v1.3.4
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           config_file: .github/other-configurations/.linkspector.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up Just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
       - name: Check Justfile Format
         run: just format-check
 
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.1
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
         with:
           version: "latest"
       - name: Run zizmor 🌈

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -20,7 +20,7 @@ jobs:
           configuration-path: .github/other-configurations/labeller.yml
           sync-labels: true
       - name: Add Size Labels
-        uses: pascalgn/size-label-action@v0.5.5
+        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/run-project-status-checker.yml
+++ b/.github/workflows/run-project-status-checker.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - name: Project Status Checker
-        uses: JackPlowman/project-status-checker@v1.0.0
+        uses: JackPlowman/project-status-checker@211cf96e37f0a948c52af6d4e6e1c7cea660ac3b # v1.0.0
         with:
           config_file_path: "github/workspace/status-checker-config.json"
           database_file_path: "github/workspace/status-checker-database.db"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Sync labels
-        uses: micnncim/action-label-syncer@v1.3.0
+        uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c # v1.3.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,22 @@ zizmor-check:
     zizmor .
 
 # ------------------------------------------------------------------------------
+# Pinact
+# ------------------------------------------------------------------------------
+
+# Run pinact
+pinact-run:
+    pinact run -c .github/other-configurations/pinact.yml
+
+# Run pinact checking
+pinact-check:
+    pinact run -c .github/other-configurations/pinact.yml --verify --check
+
+# Run pinact update
+pinact-update:
+    pinact run -c .github/other-configurations/pinact.yml --update
+
+# ------------------------------------------------------------------------------
 # Git Hooks
 # ------------------------------------------------------------------------------
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Verify:
+      run: just pinact-verify

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,4 +19,4 @@ pre-commit:
     Zizmor Checks:
       run: just zizmor-check
     Pinact Verify:
-      run: just pinact-verify
+      run: just pinact-check


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new configuration for `pinact` and updates various GitHub Actions to use specific commit SHAs for better reliability. Additionally, it includes minor updates to the `lefthook` configuration.

### New `pinact` Configuration and Integration:
* Added a `pinact` configuration file `.github/other-configurations/pinact.yml` to define ignored actions and other settings.
* Added `pinact` commands (`pinact-run`, `pinact-check`, and `pinact-update`) to the `Justfile` for running and verifying `pinact` checks.
* Integrated a `Pinact Verify` step into the `lefthook.yml` pre-commit configuration.

### GitHub Actions Updates:
* Updated multiple GitHub Actions in workflows (`code-checks.yml`, `pull-request-tasks.yml`, `run-project-status-checker.yml`, `sync-labels.yml`) to reference specific commit SHAs instead of version tags for improved stability:
  - Updated `super-linter`, `action-linkspector`, `setup-just`, and `setup-uv` in `code-checks.yml`. [[1]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L29-R29) [[2]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L48-R48) [[3]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L67-R67) [[4]](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L83-R83)
  - Updated `size-label-action` in `pull-request-tasks.yml`.
  - Updated `project-status-checker` in `run-project-status-checker.yml`.
  - Updated `action-label-syncer` in `sync-labels.yml`.

### Minor Updates:
* Bumped the minimum version of `lefthook` in `lefthook.yml` from `1.11.10` to `1.11.11`.