### PR TITLE
Add Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -127,3 +127,17 @@ jobs:
           version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow for verifying Pinact. The most important change is the introduction of the `pinact-verify` job, which includes steps for checking out the repository and installing the latest version of `uv`.

### Workflow updates:
* `.github/workflows/code-checks.yml`: Added a new job named `pinact-verify` to the workflow. This job runs on `ubuntu-latest` and includes steps to:
  - Checkout the repository using `actions/checkout@v4.2.2`.
  - Install the latest version of `uv` using `astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`.