### PR TITLE
Remove Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -127,17 +127,3 @@ jobs:
           version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes an unused workflow job from the `.github/workflows/code-checks.yml` file to streamline the CI configuration.

Workflow simplification:

* `jobs:` in `.github/workflows/code-checks.yml`: Removed the `pinact-verify` job, which included steps for checking out the repository and installing the latest version of `uv`, as it is no longer needed.