### PR TITLE
Change SuperLinter to Full Version

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       # Lint and Format everything
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
+        uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      statuses: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      # Lint and Format everything
       - name: Lint Code Base
         uses: super-linter/super-linter@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:


### PR DESCRIPTION
# Pull Request

## Description


This pull request includes a minor update to the `.github/workflows/code-checks.yml` file. The change updates the `uses` reference for the Super-Linter action to remove the `slim` suffix, aligning it with the standard repository path.
