### PR TITLE
Update License to Licence

### DIFF
--- a/.github/other-configurations/labeller.yml
+++ b/.github/other-configurations/labeller.yml
@@ -25,7 +25,7 @@ markdown:
               [
                 "docs/*.md",
                 "*.md",
-                "LICENSE",
+                "LICENCE",
                 ".github/pull_request_template.md",
               ]
 python:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the file patterns for the `markdown` label in the `.github/other-configurations/labeller.yml` configuration. The most notable change is correcting the spelling of the license file to match the British English variant.

Label configuration update:

* Changed the pattern from `LICENSE` to `LICENCE` in the list of files associated with the `markdown` label in `.github/other-configurations/labeller.yml`.