### PR TITLE
Update Prek Freeze Command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Pre-commit configuration for use with `prek` (https://github.com/j178/prek)
 
-minimum_prek_version: "0.3.0"
+minimum_prek_version: "0.4.0"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Justfile
+++ b/Justfile
@@ -97,7 +97,7 @@ prek-update:
 
 # Prek update hooks
 prek-update-hooks:
-    prek autoupdate
+    prek update --freeze
 
 prek-update-additional-dependencies:
     uv run --script https://raw.githubusercontent.com/JackPlowman/update-prek-additional-dependencies/refs/heads/main/update_prek_additional_dependencies.py
@@ -110,4 +110,3 @@ prek-update-additional-dependencies:
 update:
     just pinact-update
     just prek-update
-    just prek-update-additional-dependencies


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the project's pre-commit tooling to use newer versions and modifies the update workflow for pre-commit hooks. The most important changes are grouped below:

Pre-commit tooling updates:

* Updated the minimum required `prek` version in `.pre-commit-config.yaml` from `0.3.0` to `0.4.0`, ensuring compatibility with newer features and fixes.

Update workflow changes:

* Changed the `prek-update-hooks` command in `Justfile` to use `prek update --freeze` instead of `prek autoupdate`, which will freeze hook versions for more reproducible environments.
* Removed the `prek-update-additional-dependencies` step from the main `update` recipe in `Justfile`, streamlining the update process.